### PR TITLE
Stop `gem update --system`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ rvm:
 cache: bundler
 bundler_args: "--jobs=2"
 before_install:
-  - gem update --system --no-document
   - gem install bundler --no-document
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter


### PR DESCRIPTION
rubygems v3+ requires MRI 2.3+
https://rubygems.org/gems/rubygems-update/versions/3.0.0

So build is failed on MRI < 2.3